### PR TITLE
len gives the real length

### DIFF
--- a/test_ttldict.py
+++ b/test_ttldict.py
@@ -89,3 +89,13 @@ class TTLOrderedDictTest(TestCase):
     def test_values(self):
         ttl_dict = TTLOrderedDict(60, a=1, b=2)
         self.assertTrue(len(ttl_dict.values()), 2)
+
+    def test_len(self):
+        """ Test len() gives real length """
+        ttl_dict = TTLOrderedDict(1)
+        self.assertEqual(len(ttl_dict), 0)
+        ttl_dict['a'] = 1
+        ttl_dict['b'] = 2
+        self.assertEqual(len(ttl_dict), 2)
+        time.sleep(2)
+        self.assertEqual(len(ttl_dict), 0)

--- a/ttldict/__init__.py
+++ b/ttldict/__init__.py
@@ -22,6 +22,11 @@ class TTLOrderedDict(OrderedDict):
         return '<TTLDict@%#08x; ttl=%r, v=%r;>' % (
             id(self), self._default_ttl, super().__repr__())
 
+    def __len__(self):
+        with self._lock:
+            self._purge()
+            return super().__len__()
+
     def set_ttl(self, key, ttl, now=None):
         """Set TTL for the given key"""
         if now is None:


### PR DESCRIPTION
Asking for the length of the dict can give you an outdated length if some of the keys have already expired.