### PR TITLE
Fixed no return value for get() method

### DIFF
--- a/test_ttldict.py
+++ b/test_ttldict.py
@@ -106,3 +106,13 @@ class TTLOrderedDictTest(TestCase):
         self.assertEqual(len(ttl_dict), 2)
         time.sleep(2)
         self.assertEqual(len(ttl_dict), 0)
+
+    def test_get(self):
+        """ Test get() returns value if exists or default if not"""
+        ttl_dict = TTLOrderedDict(1)
+        ttl_dict['a'] = 1
+        self.assertEqual(ttl_dict.get('a'), 1)
+        self.assertEqual(ttl_dict.get('b', "default"), "default")
+        time.sleep(2)
+        self.assertEqual(ttl_dict.get('a', "default"), "default")
+

--- a/ttldict/__init__.py
+++ b/ttldict/__init__.py
@@ -117,6 +117,6 @@ class TTLOrderedDict(OrderedDict):
 
     def get(self, key, default=None):
         try:
-            self[key]
+            return self[key]
         except KeyError:
             return default


### PR DESCRIPTION
Fixed bug where the get() method was not returning a value when found. Added a unit test for this.

Could you release a new version if you are happy with this fix?